### PR TITLE
Feature/teardown behaviour

### DIFF
--- a/src/ClientConnection.ts
+++ b/src/ClientConnection.ts
@@ -8,7 +8,7 @@ enum CONNECTION_STEPS {
  * The child side of a connection.
  */
 export class ClientConnection extends Connection {
-  private messageListener: any;
+  protected messageListener: any;
   constructor(options: any = {}) {
     super(options);
     this.messageListener = (e: MessageEvent) => this.messageHandler(e);
@@ -55,6 +55,7 @@ export class ClientConnection extends Connection {
   protected addBeforeUnloadEvent() {
     this.options.window.addEventListener('beforeunload', (event: BeforeUnloadEvent) => {
       this.emit(MC_EVENTS.DISCONNECTED);
+      this.close();
     });
   }
 

--- a/src/ClientConnection.ts
+++ b/src/ClientConnection.ts
@@ -21,11 +21,11 @@ export class ClientConnection extends Connection {
 
   public init() {
     const url = new URL(this.options.window.location.toString());
-    const id = url.searchParams.get('mc-name');
+    this.id = url.searchParams.get('mc-name');
     if (this.options.debug) {
-      console.log('Client: sent postMessage value:', id);
+      console.log('Client: sent postMessage value:', this.id);
     }
-    this.options.window.parent.postMessage(id, this.options.targetOrigin);
+    this.options.window.parent.postMessage(this.id, this.options.targetOrigin);
   }
 
   private messageHandler(e: MessageEvent) {
@@ -42,7 +42,7 @@ export class ClientConnection extends Connection {
       this.connectionStep = CONNECTION_STEPS.HANDSHAKE;
       this.setConnectionTimeout();
     }
-    this.request(MC_EVENTS.HANDSHAKE)
+    this.request(MC_EVENTS.HANDSHAKE, null, { timeout: false })
       .then(() => {
         this.addBeforeUnloadEvent();
         this.finishInit();

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -110,7 +110,7 @@ export class Connection {
   protected options: ConnectionSettings;
   protected connectionTimeout!: number;
   protected connectionStep: string = '';
-  protected clientInitListener!: any;
+  protected messageListener!: any;
   protected readonly defaultOptions: ConnectionSettings = {
     window: window,
     connectionTimeout: 2000,
@@ -212,8 +212,8 @@ export class Connection {
       this.port.close();
       this.connected = false;
     }
-    if (this.clientInitListener) {
-      this.options.window.removeEventListener('message', this.clientInitListener, false);
+    if (this.messageListener) {
+      this.options.window.removeEventListener('message', this.messageListener, false);
     }
   }
 
@@ -221,8 +221,8 @@ export class Connection {
     clearTimeout(this.connectionTimeout);
     if (this.options.connectionTimeout !== false) {
       this.connectionTimeout = window.setTimeout(() => {
-        if (this.clientInitListener) {
-          this.options.window.removeEventListener('message', this.clientInitListener, false);
+        if (this.messageListener) {
+          this.options.window.removeEventListener('message', this.messageListener, false);
         }
         this.handleMessage({
           type: MESSAGE_TYPE.EMIT,

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -103,6 +103,7 @@ export class Connection {
    * Indicates if a connection has been established
    */
   public connected: boolean = false;
+  public id!: string | null;
   protected port!: MessagePort;
   private backlog: Array<Message> = [];
   protected promises: Promises = {};
@@ -256,6 +257,9 @@ export class Connection {
   protected finishInit() {
     this.connected = true;
     this.clearConnectionTimeout();
+    if (this.options.debug) {
+      console.log(`Finished connection on ${this.isClient() ? 'client' : 'server'}`);
+    }
     this.emit(MC_EVENTS.CONNECTED);
     this.completeBacklog();
   }

--- a/src/ServerConnection.ts
+++ b/src/ServerConnection.ts
@@ -35,14 +35,14 @@ export class ServerConnection extends Connection {
       this.setupClientInit();
     }
     this.setConnectionTimeout();
-    this.on(MC_EVENTS.DISCONNECTED, () => (this.connected = false));
+    this.on(MC_EVENTS.DISCONNECTED, () => this.close());
   }
 
   private clientInitiation(e: MessageEvent) {
     if (e.data === this.name) {
       this.connectionStep = CONNECTION_STEPS.CONNECTION;
       this.setConnectionTimeout();
-      this.options.window.removeEventListener('message', this.clientInitListener, false);
+      this.options.window.removeEventListener('message', this.messageListener, false);
       if (this.options.debug) {
         console.log('Server: Client triggered initiation');
       }
@@ -68,8 +68,8 @@ export class ServerConnection extends Connection {
     const url = new URL(this.frame.src);
     url.searchParams.append('mc-name', this.name);
     this.frame.src = url.toString();
-    this.clientInitListener = (e: MessageEvent) => this.clientInitiation(e);
-    this.options.window.addEventListener('message', this.clientInitListener);
+    this.messageListener = (e: MessageEvent) => this.clientInitiation(e);
+    this.options.window.addEventListener('message', this.messageListener);
   }
 
   /**

--- a/src/ServerConnection.ts
+++ b/src/ServerConnection.ts
@@ -11,7 +11,6 @@ enum CONNECTION_STEPS {
  */
 export class ServerConnection extends Connection {
   private channel!: MessageChannel;
-  private name!: string;
   protected connectionStep: CONNECTION_STEPS = CONNECTION_STEPS.CONNECTION;
 
   /**
@@ -27,7 +26,6 @@ export class ServerConnection extends Connection {
    */
   constructor(protected frame: HTMLIFrameElement, options: any = {}) {
     super(options);
-    this.frame.classList.add('mc-iframe');
     if (this.options.onload) {
       this.setupLoadInit();
     }
@@ -39,7 +37,7 @@ export class ServerConnection extends Connection {
   }
 
   private clientInitiation(e: MessageEvent) {
-    if (e.data === this.name) {
+    if (e.data === this.id) {
       this.connectionStep = CONNECTION_STEPS.CONNECTION;
       this.setConnectionTimeout();
       this.options.window.removeEventListener('message', this.messageListener, false);
@@ -63,10 +61,9 @@ export class ServerConnection extends Connection {
 
   private setupClientInit() {
     this.connectionStep = CONNECTION_STEPS.INITIATION_FROM_CLIENT;
-    const numFrames = this.options.window.document.querySelectorAll('iframe.mc-iframe').length;
-    this.name = 'mc-' + numFrames;
+    this.id = this.uuidv4();
     const url = new URL(this.frame.src);
-    url.searchParams.append('mc-name', this.name);
+    url.searchParams.set('mc-name', this.id);
     this.frame.src = url.toString();
     this.messageListener = (e: MessageEvent) => this.clientInitiation(e);
     this.options.window.addEventListener('message', this.messageListener);
@@ -93,8 +90,8 @@ export class ServerConnection extends Connection {
 
   private listenForHandshake() {
     this.on(MC_EVENTS.HANDSHAKE, (payload: any, resolve: Function) => {
-      this.finishInit();
       resolve(payload);
+      this.finishInit();
     });
   }
 

--- a/test/Connection.spec.ts
+++ b/test/Connection.spec.ts
@@ -22,16 +22,16 @@ describe('Connection', () => {
     it('should set timeout if timeout option is passed', async () => {
       const connection = new Connection();
       try {
-        await connection.request('test', {timeout: 1});
-      } catch(e) {
+        await connection.request('test', { timeout: 1 });
+      } catch (e) {
         expect(e).toEqual('timeout');
       }
     });
     it('should set timeout if timeout option is passed', async () => {
       const connection = new Connection();
       try {
-        await connection.request('test', {timeout: 1});
-      } catch(e) {
+        await connection.request('test', { timeout: 1 });
+      } catch (e) {
         expect(e).toEqual('timeout');
       }
     });
@@ -41,7 +41,7 @@ describe('Connection', () => {
     it('should close port if connected', () => {
       const connection = new Connection();
       //@ts-ignore
-      connection.port = {close: () => {}};
+      connection.port = { close: () => {} };
       //@ts-ignore
       spyOn(connection.port, 'close');
       connection.connected = true;
@@ -53,7 +53,7 @@ describe('Connection', () => {
     it('should remove event listener if client inits listener', () => {
       const connection = new Connection();
       //@ts-ignore
-      connection.clientInitListener = true;
+      connection.messageListener = true;
       //@ts-ignore
       spyOn(connection.options.window, 'removeEventListener');
       connection.close();
@@ -64,7 +64,7 @@ describe('Connection', () => {
 
   describe('initPortEvents()', () => {
     it('should handle error on message error', () => {
-      const connection = new Connection({debug: true});
+      const connection = new Connection({ debug: true });
       //@ts-ignore
       connection.port = {};
       //@ts-ignore
@@ -92,7 +92,7 @@ describe('Connection', () => {
       expect(timeout).toEqual(0);
     });
     it('should return options.timeout if timeout is true', () => {
-      const connection = new Connection({timeout: 100});
+      const connection = new Connection({ timeout: 100 });
       //@ts-ignore
       const timeout = connection.getRequestTimeout(true);
       expect(timeout).toEqual(100);
@@ -107,10 +107,10 @@ describe('Connection', () => {
 
   describe('portMessage()', () => {
     it('should call console.log if debug enabled', () => {
-      const connection = new Connection({debug: true});
+      const connection = new Connection({ debug: true });
       spyOn(console, 'log');
       //@ts-ignore
-      connection.port = {postMessage: () => {}};
+      connection.port = { postMessage: () => {} };
       //@ts-ignore
       connection.portMessage(MESSAGE_TYPE.EMIT);
       expect(console.log).toHaveBeenCalled();


### PR DESCRIPTION
* Disconnection will now call `close()` to cleanup events instead of just setting connection status.
* Unified message listener callback naming so now both 'client' and 'server' remove initiation event listener on close.
* Id generation is now much less likely to produce collisions.
* Made Id an accessible top level value on both 'client' and 'server'.
* Removed timeout from handshake, slowdown in browser can mean the default timeout of 200ms can be reached.
* Changed order of completion steps to prioritise the handshake.